### PR TITLE
Minimal support to convert TODO/DONE markers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nrepl-port
 .cpcache/
 .lsp/
+tmp/

--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ directory tree, suitable for importing into logseq.
 
 There are several known weaknesses of this tool.
 
-- `TODO`/`DONE` in Athens is not converted to logseq's format (either the
-  later/now/done style or todo/done).
+- `TODO`/`DONE` in Athens is rudimentarily converted to logseq's format using
+  TODO and DONE markers. Keep in mind that logseq will only recognize them if
+  they are the begining of a block (Athens allows you to randomly add them
+  anywhere on the block, if you rely on that, you will have to manually fix
+  your files).
 - iframe and YouTube embeds are not converted
   - they are visible (flagged as errors) in logseq, and can be edited to work.
 - code blocks are clumsy in Athens, and show up misformatted in logseq

--- a/src/athens/export.clj
+++ b/src/athens/export.clj
@@ -40,10 +40,23 @@
       (cons text children-indented)
       children-indented)))
 
+(defn convert-todos [text]
+  "Converts TODO/DONE state. Athens may allow TODO markers mid sentence.
+  However logseq expect those at the begining of the block. If you have
+  TODO markers mid block with text preceeding it, you may need to manually
+  look for those after the conversion. Logseq also does not use [ ] and [X]
+  syntax like other MD-aware tools. The reason, logseq allows  configurable
+  TODO flows based on  multiple labels to toggle from. Priorities are not
+  supported in Athens, hence, nothing to convert here."
+  (-> text
+      (string/replace #"\{\{TODO\}\}|\{\{\[\[TODO\]\]\}\}" "TODO")
+      (string/replace #"\{\{DONE\}\}|\{\{\[\[DONE\]\]\}\}" "DONE")))
+
 (defn block->file [db block-refs filename preamble block]
   (->> (markdown-block db block-refs block)
        (string/join \newline)
        (str (or preamble ""))
+       (convert-todos)
        (spit filename)))
 
 (defn page-path

--- a/src/athens/export.clj
+++ b/src/athens/export.clj
@@ -42,8 +42,8 @@
 
 (defn convert-todos [text]
   "Converts TODO/DONE state. Athens may allow TODO markers mid sentence.
-  However logseq expect those at the begining of the block. If you have
-  TODO markers mid block with text preceeding it, you may need to manually
+  However logseq expect those at the beginning of the block. If you have
+  TODO markers mid block with text preceding it, you may need to manually
   look for those after the conversion. Logseq also does not use [ ] and [X]
   syntax like other MD-aware tools. The reason, logseq allows  configurable
   TODO flows based on  multiple labels to toggle from. Priorities are not


### PR DESCRIPTION
Logseq does not use [ ] and [X] syntax like other MD-aware tools. The reason, logseq allows configurable TODO flows based on  multiple labels to toggle from. Priorities are not supported in Athens, hence, nothing to convert here. Athens may allow TODO markers mid sentence. However logseq expect those at the beginning of the block. If you have TODO markers mid block with text preceding it, you may need to manually look for those after the conversion.