### PR TITLE
Add oneliner to README for downloading latest release jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The easiest way is to download a [released
 JAR](https://github.com/shepheb/athens-export/releases), and run it with
 
 ```
+$ wget https://github.com/bshepherdson/athens-export/releases/latest/download/athens-export.jar
 $ java -jar athens-export.jar path/to/athens/index.transit logseq/parent/dir
 ```
 


### PR DESCRIPTION
I always have a hard time remembering the format to download from github releases. 

I added a section to the readme with the wget command for downloading the latest release.