### PR TITLE
multiple block refs bug fix

### DIFF
--- a/src/athens/export.clj
+++ b/src/athens/export.clj
@@ -116,7 +116,7 @@
     {:db/id eid
      :block/string text
      :block/ref block-ref
-     :export/uuid (.toString (UUID/randomUUID))}))
+     :export/uuid (.toString (UUID/nameUUIDFromBytes (.getBytes block-ref)))}))
 
 (defn export
   "Given the in-memory database and a target directory, output everything there.


### PR DESCRIPTION
fixed wrong block ref when a block has more than two refs. UUID changed to be deterministic function of athens block-id

Basically was caused by undefined behaviour, since each block-ref got several UUID, and the regex substitution used the first one while the actual block id assignment used the last one.

This should resolve #2.